### PR TITLE
Enhanced status command with changelist filtering

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -125,7 +125,30 @@ git cl st
 ```
 
 - Like `git status --porcelain`, but grouped by changelist.
-- Shows Git’s precise two-letter status codes.
+- Shows Git’s precise two-letter status codes, grouped under each changelist.
+- Files not assigned to any changelist appear under No Changelist.
+
+##### Filtering by changelist name
+
+You can pass one or more changelist names to show only those specific groups:
+
+```
+git cl status docs tests
+# or
+git cl st frontend-refactor
+```
+
+This limits the output to the specified changelists. By default, unassigned files (those in “No Changelist”) are hidden in this mode.
+
+If you want to include unassigned files alongside named changelists, use the `--include-no-cl` flag:
+
+```
+git cl st docs --include-no-cl
+```
+
+#### Showing all Git status codes
+
+By default, git cl status shows only the most common status codes (like [M ], [??], [ D], etc.) for clarity.
 
 The following table explains the status codes shown in `git cl status`, which follow Git’s `--porcelain` format:
 

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -150,7 +150,20 @@ git cl st docs --include-no-cl
 
 By default, git cl status shows only the most common status codes (like [M ], [??], [ D], etc.) for clarity.
 
-The following table explains the status codes shown in `git cl status`, which follow Git’s `--porcelain` format:
+To include all Git status codes — including merge conflicts, type changes, or ignored files — use the `--all` flag:
+
+```
+git cl st --all
+```
+
+This reveals additional cases like
+
+| Code  | Description             |
+| ----- | ----------------------- |
+| \[UU] | Unmerged (conflict)     |
+| \[T ] | Type change             |
+
+#### Status code reference
 
 | Code	| Meaning                    	 | Description                                            |
 | ----- | ---------------------------- | ------------------------------------------------------ |
@@ -165,28 +178,23 @@ The following table explains the status codes shown in `git cl status`, which fo
 | [R ]  |	Renamed	                     | File was renamed and the change is staged              |
 | [RM]  |	Renamed + Modified	         | File was renamed and then modified before staging      |
 
-For a full list of Git status codes and their meanings, see the official [git documentation](https://git-scm.com/docs/git-status). 
 
-By default, `git cl status` shows only common Git status codes. To include files with uncommon or advanced status codes (like merge conflicts, type changes, or ignored files), use the `--all` flag:
+See the full list of codes in the [Git documentation](https://git-scm.com/docs/git-status). 
 
-```
-git cl status --all
-```
-
-#### Example Output:
+#### Example
 
 ```
-   docs:
-  [M ] README.md        # This change is staged
-  [ M] docs/index.md    # This change is not staged
+$ git cl st docs --include-no-cl --all
 
-tests:
-  [A ] tests/dev_env.sh # This new file is staged
+docs:
+  [ M] docs/index.md
+  [A ] docs/new_section.md
 
 No Changelist:
-  [ M] main.py
   [??] scratch.txt
+  [UU] merge_conflict_file.py
 ```
+
 
 ### 2.4 Stage a changelist
 
@@ -378,7 +386,7 @@ This will show all files, including those with status codes like [UU] (unmerged)
 | Commit with inline message     | `git cl ci <name> -m "Message" [--keep]`       |
 | Commit using message from file | `git cl ci <name> -F message.txt [--keep]`     |
 | Remove files from changelists  | `git cl remove <file1> <file2> ...`            |
-| Delete changelists             | `git cl delete <name1> <name2>` ...`           |
+| Delete changelists             | `git cl delete <name1> <name2> ...`            |
 | Delete all changelists         | `git cl delete --all`                          |
 | Show help                      | `git cl help`                                  |
 

--- a/git-cl
+++ b/git-cl
@@ -794,8 +794,8 @@ def main() -> None:
         help='Optional list of changelists to show (default: all)')
     status_parser.add_argument(
         '--include-no-cl', action='store_true',
-        help=('Also show files not assigned to any changelist '
-              '("No Changelist")'))
+        help=('When filtering by changelist names, also show files '
+              'not assigned to any changelist'))
     status_parser.add_argument(
         '--all', action='store_true',
         help='Include files with uncommon Git status codes')

--- a/git-cl
+++ b/git-cl
@@ -544,6 +544,18 @@ def cl_list(_args: argparse.Namespace) -> None:
 def cl_status(args: argparse.Namespace) -> None:
     """
     Displays git status grouped by changelist membership.
+
+    If no changelists are specified, shows all changelists plus files
+    not assigned to any changelist ("No Changelist").
+
+    If one or more changelist names are given as arguments, limits output
+    to those changelists only. By default, unassigned files are not shown
+    in this mode unless --include-no-cl is also specified.
+
+    By default, only files with 'interesting' status codes (e.g., modified,
+    added, deleted) are shown. Use --all to also include files with other
+    status codes such as merge conflicts, unmerged files, or other special
+    states reported by git status.
     """
     selected_names = set(args.names) if args.names else None
     changelists = clutil_load()

--- a/git-cl
+++ b/git-cl
@@ -545,24 +545,28 @@ def cl_status(args: argparse.Namespace) -> None:
     """
     Displays git status grouped by changelist membership.
     """
+    selected_names = set(args.names) if args.names else None
     changelists = clutil_load()
     git_root = clutil_get_git_root()
     status_map = clutil_get_file_status_map(show_all=args.all)
 
     assigned_files = set()
     for cl_name, files in changelists.items():
+        if selected_names is not None and cl_name not in selected_names:
+            continue
         print(f"{cl_name}:")
         for file in files:
             print(clutil_format_file_status(file, status_map, git_root))
         assigned_files.update(files)
 
-    no_cl_files = [file for file in status_map if file not in assigned_files]
-    if no_cl_files:
-        print("No Changelist:")
-        for file in sorted(no_cl_files):
-            status = status_map[file]
-            tag = f"[{status}]" if status != "  " else "[  ]"
-            print(f"  {tag} {file}")
+    if selected_names is None:
+        no_cl_files = [file for file in status_map if file not in assigned_files]
+        if no_cl_files:
+            print("No Changelist:")
+            for file in sorted(no_cl_files):
+                status = status_map[file]
+                tag = f"[{status}]" if status != "  " else "[  ]"
+                print(f"  {tag} {file}")
 
 
 def cl_remove(args: argparse.Namespace) -> None:
@@ -773,6 +777,9 @@ def main() -> None:
         help='Show file changes grouped by changelist',
         description=("Show file changes grouped by changelist. "
                      "Unassigned files appear under 'No Changelist'."))
+    status_parser.add_argument(
+        'names', metavar='CHANGELIST', nargs='*',
+        help='Optional list of changelists to show (default: all)')
     status_parser.add_argument(
         '--all', action='store_true',
         help='Include files with uncommon Git status codes')

--- a/git-cl
+++ b/git-cl
@@ -560,7 +560,7 @@ def cl_status(args: argparse.Namespace) -> None:
     selected_names = set(args.names) if args.names else None
     changelists = clutil_load()
     git_root = clutil_get_git_root()
-    status_map = clutil_get_file_status_map(show_all=args.all)
+    st_map = clutil_get_file_status_map(show_all=args.all)
 
     assigned_files = set()
     for cl_name, files in changelists.items():
@@ -568,15 +568,15 @@ def cl_status(args: argparse.Namespace) -> None:
             continue
         print(f"{cl_name}:")
         for file in files:
-            print(clutil_format_file_status(file, status_map, git_root))
+            print(clutil_format_file_status(file, st_map, git_root))
         assigned_files.update(files)
 
     if selected_names is None or args.include_no_cl:
-        no_cl_files = [file for file in status_map if file not in assigned_files]
+        no_cl_files = [file for file in st_map if file not in assigned_files]
         if no_cl_files:
             print("No Changelist:")
             for file in sorted(no_cl_files):
-                status = status_map[file]
+                status = st_map[file]
                 tag = f"[{status}]" if status != "  " else "[  ]"
                 print(f"  {tag} {file}")
 
@@ -794,7 +794,8 @@ def main() -> None:
         help='Optional list of changelists to show (default: all)')
     status_parser.add_argument(
         '--include-no-cl', action='store_true',
-        help='Also show files not assigned to any changelist ("No Changelist")')    
+        help=('Also show files not assigned to any changelist '
+              '("No Changelist")'))
     status_parser.add_argument(
         '--all', action='store_true',
         help='Include files with uncommon Git status codes')

--- a/git-cl
+++ b/git-cl
@@ -559,7 +559,7 @@ def cl_status(args: argparse.Namespace) -> None:
             print(clutil_format_file_status(file, status_map, git_root))
         assigned_files.update(files)
 
-    if selected_names is None:
+    if selected_names is None or args.include_no_cl:
         no_cl_files = [file for file in status_map if file not in assigned_files]
         if no_cl_files:
             print("No Changelist:")
@@ -780,6 +780,9 @@ def main() -> None:
     status_parser.add_argument(
         'names', metavar='CHANGELIST', nargs='*',
         help='Optional list of changelists to show (default: all)')
+    status_parser.add_argument(
+        '--include-no-cl', action='store_true',
+        help='Also show files not assigned to any changelist ("No Changelist")')    
     status_parser.add_argument(
         '--all', action='store_true',
         help='Include files with uncommon Git status codes')


### PR DESCRIPTION
This PR enhances the git cl status command to support filtering by specific changelist names, making it easier for users to focus on relevant changelists in repositories with many active changes.