### PR TITLE
Add git cl checkout command for reverting changelist files

### DIFF
--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -16,16 +16,13 @@ git-cl: A Git subcommand to manage changelists in Git. Group files by intent, ma
 - [2. Basic Commands](#2-basic-commands)
   - [2.1 Add files to a changelist](#21-add-files-to-a-changelist)
   - [2.2 View status by changelist](#22-view-status-by-changelist) 
-    - [Filtering by changelist name](#filtering-by-changelist-name)
-    - [Showing all Git status codes](#showing-all-git-status-codes)
-    - [Git Status codes](#git-status-codes)
-    - [Color Key](#color-key)
   - [2.3 Diff a changelist](#23-diff-a-changelist) 
   - [2.4 Stage and unstage a changelist](#24-stage-and-unstage-a-changelist)
   - [2.5 Commit a changelist](#25-commit-a-changelist)
   - [2.6 Remove files from changelists](#26-remove-files-from-changelists)
   - [2.7 Delete changelists](#27-delete-changelists)
   - [2.8 Stash and Unstash Changelists](#28-stash-and-unstash-changelists)
+  - [2.9 Checkout a Changelist](#29-checkout-a-changelist)
 - [3. Example Workflows](#3-example-workflows)
   - [3.1 Changelists as Named Staging Areas](#31-changelists-as-named-staging-areas)
   - [3.2 Branching Mid-Feature with git cl stash](#32-branching-mid-feature-with-git-cl-stash)
@@ -368,6 +365,19 @@ git cl stash --all
 
 - Stashes all active changelists at once
 
+### 2.9 Checkout a Changelist
+
+```
+git cl checkout <changelist-name>
+# or
+git cl co <changelist-name>
+```
+
+- Reverts all files in the changelist to their last committed state ([HEAD](https://git-scm.com/book/ms/v2/Git-Tools-Reset-Demystified.html#_the_head)).
+- Useful for discarding local changes by intent, not just by filename.
+- Prompts for confirmation before proceeding.
+- Shows a summary of reverted files.
+
 [↑ Back to top](#git-cl-a-git-subcommand-for-changelist-management)
 
 ## 3. Example Workflows
@@ -507,6 +517,7 @@ This will show all files, including those with status codes like `[UU]` (unmerge
 | Unstage a changelist           | `git cl unstage <name> [--delete]`             |              |
 | Commit with inline message     | `git cl commit <name> -m "Message" [--keep]`   | `git cl ci`  |
 | Commit using message from file | `git cl commit <name> -F message.txt [--keep]` |              |
+| Revert changelist to HEAD	     | `git cl checkout <name>`                       |	`git cl co`  |
 | Remove files from changelists  | `git cl remove <file1> <file2> ...`            | `git cl rm`  |
 | Delete changelists             | `git cl delete <name1> <name2> ...`            | `git cl del` | 
 | Delete all changelists         | `git cl delete --all`                          |              |

--- a/git-cl
+++ b/git-cl
@@ -2167,6 +2167,112 @@ def cl_diff(args: argparse.Namespace) -> None:
         print(f"Error running git diff: {error}")
 
 
+def cl_checkout(args: argparse.Namespace) -> None:
+    """
+    Checkout (revert) files from one or more changelists to their HEAD state.
+
+    This discards local changes in the working directory for the specified files,
+    reverting them to their last committed state. Useful for undoing unwanted
+    local modifications.
+ 
+    Args:
+        args: argparse.Namespace with 'names' list of changelist names,
+              and optional 'force' flag for confirmation.
+    """
+    changelists = clutil_load()
+    git_root = clutil_get_git_root()
+
+    # Collect all files from specified changelists
+    all_files = []
+    missing_changelists = []
+
+    for name in args.names:
+        if name not in changelists:
+            missing_changelists.append(name)
+            continue
+            
+        files = changelists[name]
+        if not files:
+            print(f"Warning: Changelist '{name}' is empty.")
+            continue
+
+        all_files.extend(files)
+
+    # Report missing changelists
+    if missing_changelists:
+        print(f"Error: The following changelists were not found:")
+        for name in missing_changelists:
+            print(f"  {name}")
+        if not all_files:  # No valid changelists found
+            return
+    
+    if not all_files:
+        print("No files to checkout.")
+        return
+
+    # Convert to paths relative to current working directory for git command
+    checkout_files = []
+    missing_files = []
+
+    for stored_path in all_files:
+        abs_path = (git_root / stored_path).resolve()
+
+        if not abs_path.exists():
+            missing_files.append(stored_path)
+            continue
+
+        rel_to_cwd = os.path.relpath(abs_path, Path.cwd())
+        checkout_files.append(rel_to_cwd)
+
+    # Report missing files
+    if missing_files:
+        print("Warning: The following files do not exist and will be skipped:")
+        for file_path in missing_files:
+            print(f"  {file_path}")
+
+    if not checkout_files:
+        print("No existing files to checkout.")
+        return
+
+    # Show what will be affected and ask for confirmation unless --force
+    print(f"This will discard local changes in {len(checkout_files)} file(s):")
+    for file_path in checkout_files[:10]:  # Show first 10 files
+        print(f"  {file_path}")
+    if len(checkout_files) > 10:
+        print(f"  ... and {len(checkout_files) - 10} more files")
+
+    if not args.force:
+        try:
+            response = input("\nProceed? [y/N]: ").strip().lower()
+            if response not in ('y', 'yes'):
+                print("Checkout cancelled.")
+                return
+        except (EOFError, KeyboardInterrupt):
+            print("\nCheckout cancelled.")
+            return
+
+    # Perform the checkout
+    try:
+        subprocess.run(["git", "checkout", "HEAD", "--"] + checkout_files, 
+                      check=True)
+        print(f"Successfully reverted {len(checkout_files)} file(s) to HEAD state.")
+
+        # Show summary by changelist
+        print("\nFiles reverted by changelist:")
+        for name in args.names:
+            if name in changelists and changelists[name]:
+                reverted_count = sum(1 for f in changelists[name] 
+                                   if f in all_files and 
+                                   (git_root / f).resolve().exists())
+                if reverted_count > 0:
+                    print(f"  {name}: {reverted_count} files")
+
+    except subprocess.CalledProcessError as error:
+        print(f"Error during checkout: {error}")
+        print("Some files may not have been reverted.")
+        return
+
+
 def cl_remove(args: argparse.Namespace) -> None:
     """
     Removes one or more files from any changelists they are part of.
@@ -2563,6 +2669,22 @@ def main() -> None:
                              help='Show both unstaged and staged diffs')
     diff_parser.set_defaults(func=cl_diff)
 
+    # checkout / co
+    checkout_parser = subparsers.add_parser('checkout', aliases=['co'],
+                                           help='Checkout (revert) files from changelists',
+                                           description=(
+                                               "Revert files in one or more changelists "
+                                               "to their HEAD state, discarding any local "
+                                               "changes in the working directory. This is "
+                                               "useful for undoing unwanted modifications. "
+                                               "By default, asks for confirmation before "
+                                               "proceeding."))
+    checkout_parser.add_argument('names', metavar='CHANGELIST', nargs='+',
+                                help='One or more changelists to checkout/revert')
+    checkout_parser.add_argument('--force', '-f', action='store_true',
+                                help='Skip confirmation prompt')
+    checkout_parser.set_defaults(func=cl_checkout)
+    
     # stage
     stage_parser = subparsers.add_parser('stage',
                                          help=("Stage tracked files from a "

--- a/git-cl
+++ b/git-cl
@@ -2190,7 +2190,7 @@ def cl_checkout(args: argparse.Namespace) -> None:
         if name not in changelists:
             missing_changelists.append(name)
             continue
-            
+
         files = changelists[name]
         if not files:
             print(f"Warning: Changelist '{name}' is empty.")
@@ -2205,7 +2205,7 @@ def cl_checkout(args: argparse.Namespace) -> None:
             print(f"  {name}")
         if not all_files:  # No valid changelists found
             return
-    
+
     if not all_files:
         print("No files to checkout.")
         return
@@ -2253,7 +2253,7 @@ def cl_checkout(args: argparse.Namespace) -> None:
 
     # Perform the checkout
     try:
-        subprocess.run(["git", "checkout", "HEAD", "--"] + checkout_files, 
+        subprocess.run(["git", "checkout", "HEAD", "--"] + checkout_files,
                       check=True)
         print(f"Successfully reverted {len(checkout_files)} file(s) to HEAD state.")
 
@@ -2261,8 +2261,8 @@ def cl_checkout(args: argparse.Namespace) -> None:
         print("\nFiles reverted by changelist:")
         for name in args.names:
             if name in changelists and changelists[name]:
-                reverted_count = sum(1 for f in changelists[name] 
-                                   if f in all_files and 
+                reverted_count = sum(1 for f in changelists[name]
+                                   if f in all_files and
                                    (git_root / f).resolve().exists())
                 if reverted_count > 0:
                     print(f"  {name}: {reverted_count} files")
@@ -2689,7 +2689,7 @@ def main() -> None:
     checkout_parser.add_argument('--force', '-f', action='store_true',
                                 help='Skip confirmation prompt')
     checkout_parser.set_defaults(func=cl_checkout)
-    
+
     # stage
     stage_parser = subparsers.add_parser('stage',
                                          help=("Stage tracked files from a "

--- a/git-cl
+++ b/git-cl
@@ -2669,16 +2669,23 @@ def main() -> None:
                              help='Show both unstaged and staged diffs')
     diff_parser.set_defaults(func=cl_diff)
 
-    # checkout / co
+    # checkout
     checkout_parser = subparsers.add_parser('checkout', aliases=['co'],
-                                            help='Checkout (revert) files from changelists',
+                                            help=("Checkout (revert) files "
+                                                  "from changelists"),
                                             description=(
-                                                "Revert files in one or more changelists to their HEAD state, "
-                                                "discarding both staged and unstaged changes in those files. "
-                                                "This completely restores files to their last committed state. "
-                                                "By default, asks for confirmation before proceeding."))
+                                                "Revert files in one or more "
+                                                "changelists to their HEAD "
+                                                "state, discarding both "
+                                                "staged and unstaged changes "
+                                                "in those files. This "
+                                                "completely restores files "
+                                                "to their last committed "
+                                                "state. By default, asks for "
+                                                " confirmation before "
+                                                "proceeding."))
     checkout_parser.add_argument('names', metavar='CHANGELIST', nargs='+',
-                                help='One or more changelists to checkout/revert')
+                                help='One or more changelists to checkout')
     checkout_parser.add_argument('--force', '-f', action='store_true',
                                 help='Skip confirmation prompt')
     checkout_parser.set_defaults(func=cl_checkout)

--- a/git-cl
+++ b/git-cl
@@ -2671,14 +2671,12 @@ def main() -> None:
 
     # checkout / co
     checkout_parser = subparsers.add_parser('checkout', aliases=['co'],
-                                           help='Checkout (revert) files from changelists',
-                                           description=(
-                                               "Revert files in one or more changelists "
-                                               "to their HEAD state, discarding any local "
-                                               "changes in the working directory. This is "
-                                               "useful for undoing unwanted modifications. "
-                                               "By default, asks for confirmation before "
-                                               "proceeding."))
+                                            help='Checkout (revert) files from changelists',
+                                            description=(
+                                                "Revert files in one or more changelists to their HEAD state, "
+                                                "discarding both staged and unstaged changes in those files. "
+                                                "This completely restores files to their last committed state. "
+                                                "By default, asks for confirmation before proceeding."))
     checkout_parser.add_argument('names', metavar='CHANGELIST', nargs='+',
                                 help='One or more changelists to checkout/revert')
     checkout_parser.add_argument('--force', '-f', action='store_true',


### PR DESCRIPTION
# Summary

Implements git cl checkout (alias: git cl co) to revert files in specified changelists to their HEAD state, discarding both staged and unstaged changes.

# Usage

```
# Revert files in a single changelist
git cl co my-feature

# Revert files in multiple changelists  
git cl co feature-1 feature-2 bugfix

# Skip confirmation prompt
git cl co my-feature --force
```

# Features

- Multiple changelist support: Process several changelists in one command
- Safety first: Confirmation prompt with preview (bypass with --force/-f)
- Complete reversion: Uses git checkout HEAD -- to discard both staged and unstaged changes
- Clear feedback: Shows which files will be affected and provides summary by changelist
- Error handling: Reports missing changelists and non-existent files

# Use Cases

- Quickly undo experimental changes across multiple related changelists
- Clean slate before switching development direction
- Revert accidental modifications while preserving changelist organisation

# Implementation Notes

- Follows existing code patterns and error handling conventions
- Leverages existing utility functions for path resolution and Git operations
- No duplicate handling needed since files can only exist in one changelist