### PR TITLE
Add missing file warnings to cl_add for consistency

### DIFF
--- a/git-cl
+++ b/git-cl
@@ -1953,6 +1953,10 @@ def cl_add(args: argparse.Namespace) -> None:
     for file in args.files:
         sanitized = clutil_sanitize_path(file, git_root)
         if sanitized:
+            # Check if file exists and warn if not
+            abs_path = (git_root / sanitized).resolve()
+            if not abs_path.exists():
+                print(f"Warning: File '{file}' does not exist.")
             files.append(sanitized)
         else:
             print(f"Warning: Skipping invalid or unsafe path: '{file}'")


### PR DESCRIPTION
The cl_add command was silently adding non-existent files to changelists without warning users, unlike other commands (cl_stage, cl_commit, etc.) which warn about missing files.

Changes:
- Check file existence when adding to changelist
- Show warning for files that don't exist but still add them
- Maintains workflow flexibility while providing user feedback
- Brings cl_add behavior in line with other commands

This allows users to add files they plan to create while alerting them to potential typos or missing files.