### PR TITLE
Add --no-untracked option to git cl status

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,8 +9,8 @@ url: "https://github.com/BHFock/git-cl"
 repository-code: "https://github.com/BHFock/git-cl"
 license: BSD-3-Clause
 doi: "10.5281/zenodo.18722077"
-version: "1.1.6"
-date-released: "2026-04-17"
+version: "1.1.7"
+date-released: "2026-05-16"
 abstract: >-
   git-cl is a command-line tool that brings changelist support to Git.
   It introduces a pre-staging layer that allows developers to partition

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -167,6 +167,16 @@ Example output of `git cl st`, showing files grouped by changelist with standard
      alt="git cl st output showing changelists feature1, feature2, and No Changelist with colour-coded status codes"
      width="200"/>
 
+#### Hiding untracked files
+
+If your repository has many untracked files that clutter the output, you can hide them with `--no-untracked`:
+
+```
+git cl st --no-untracked
+```
+
+This is useful when working on a focused task and you only want to see files already known to Git.
+
 ### 2.3 Diff a changelist
 
 ```
@@ -609,7 +619,7 @@ Yes. Each worktree has its own independent set of changelists — changes made i
 | Task                            | Command                                                   | Alias         | 
 | ------------------------------- | --------------------------------------------------------- | ------------- |
 | Add files to a changelist       | `git cl add <name> <files...>`                            | `git cl a`    |
-| View grouped status             | `git cl status [--all] [--no-color] `                     | `git cl st`   | 
+| View grouped status             | `git cl status [--all] [--no-untracked] [--no-color]`     | `git cl st`   |
 | Show diff for changelist(s)     | `git cl diff <name1> [<name2> ...] [--staged]`            |               |
 | Stage a changelist              | `git cl stage <name> [--delete]`                          |               |
 | Unstage a changelist            | `git cl unstage <name> [--delete]`                        |               |

--- a/git-cl
+++ b/git-cl
@@ -370,6 +370,8 @@ def clutil_get_git_status(include_untracked: bool = False) -> list[str]:
     cmd = ["git", "status", "--porcelain"]
     if include_untracked:
         cmd.append("--untracked-files=all")
+    else:
+        cmd.append("--untracked-files=no")
 
     try:
         return subprocess.check_output(cmd, text=True).splitlines()

--- a/git-cl
+++ b/git-cl
@@ -56,7 +56,7 @@ Single file, zero dependencies beyond Python 3.9+ and Git.
 Cross-platform: Unix (fcntl) and Windows (msvcrt) file locking.
 """
 
-__version__ = "1.1.6"
+__version__ = "1.1.7"
 
 import argparse
 import datetime

--- a/git-cl
+++ b/git-cl
@@ -422,7 +422,9 @@ def clutil_sanitize_path(file_path: str, git_root: Path) -> Optional[str]:
         return None
 
 
-def clutil_get_file_status_map(show_all: bool = False) -> dict[str, str]:
+def clutil_get_file_status_map(
+        show_all: bool = False,
+        include_untracked: bool = True) -> dict[str, str]:
     """
     Get a mapping of files to their Git 2-letter status codes.
 
@@ -436,13 +438,15 @@ def clutil_get_file_status_map(show_all: bool = False) -> dict[str, str]:
 
     Args:
         show_all (bool): If True, include all files regardless of status code.
+        include_untracked (bool): If True (default), list every untracked file.
+            If False, untracked files are excluded entirely from the status map.
 
     Returns:
         dict[str, str]: Mapping of relative file paths
                         to their Git status codes.
     """
     git_root = clutil_get_git_root()
-    output = clutil_get_git_status(include_untracked=True)
+    output = clutil_get_git_status(include_untracked=include_untracked)
 
     # Allowlist of known meaningful status codes
     INTERESTING_CODES = {
@@ -2525,7 +2529,9 @@ def cl_status(args: argparse.Namespace) -> None:
     changelists = clutil_load()
     stashes = clutil_load_stashes()
     git_root = clutil_get_git_root()
-    status_map = clutil_get_file_status_map(show_all=args.all)
+    status_map = clutil_get_file_status_map(
+        show_all=args.all,
+        include_untracked=not args.no_untracked)
 
     use_color = clutil_should_use_color(args)
 
@@ -3241,6 +3247,8 @@ def main() -> None:
     status_parser.add_argument('--all', action='store_true',
                                help=("Include files with uncommon Git "
                                      "status codes"))
+    status_parser.add_argument('--no-untracked', action='store_true',
+                               help='Hide untracked files (??) from output')
     status_parser.add_argument('--no-color', action='store_true',
                                help='Disable colored output')
     status_parser.set_defaults(func=cl_status)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = git-changelists
-version = 1.1.6
+version = 1.1.7
 author = Bjoern Hendrik Fock
 description = Git subcommand for named changelist support. Group working directory files by intent, then stage, commit, or branch by changelist.
 long_description = file: README.md


### PR DESCRIPTION
### Description:

Adds a new `--no-untracked flag` to `git cl status` that hides untracked files (`??`) from the output.

By default, `git cl status` lists every untracked file individually (using `git status --untracked-files=all`), which differs from `git status`'s default behaviour and can clutter the output in repositories with many untracked files. The new flag passes `--untracked-files=no` to Git, suppressing untracked files entirely.

The flag is orthogonal to `--all` — they can be combined to show all uncommon status codes except untracked files.

Default behaviour is unchanged: untracked files are still shown unless `--no-untracked` is explicitly passed.

### Example:

```
$ git cl status
No Changelist:
  [??] notes/draft.md
  [ M] src/core.py

$ git cl status --no-untracked
No Changelist:
  [ M] src/core.py
```

### Changes:

*  New `--no-untracked` flag on the `status` subcommand
* New `include_untracked` parameter on `clutil_get_file_status_map` (default `True`, preserves existing behaviour for all other callers)
* `clutil_get_git_status` now passes `--untracked-files=no` explicitly when untracked files are not requested

Version bumped to 1.1.7