### PR TITLE
Fix files from other changelists shown under "No Changelist" when filtering

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,8 +9,8 @@ url: "https://github.com/BHFock/git-cl"
 repository-code: "https://github.com/BHFock/git-cl"
 license: BSD-3-Clause
 doi: "10.5281/zenodo.18722077"
-version: "1.1.7"
-date-released: "2026-05-16"
+version: "1.1.8"
+date-released: "2026-05-22"
 abstract: >-
   git-cl is a command-line tool that brings changelist support to Git.
   It introduces a pre-staging layer that allows developers to partition

--- a/git-cl
+++ b/git-cl
@@ -2143,27 +2143,24 @@ def clutil_show_active_changelists(
     shown_any = False
 
     for cl_name, files in changelists.items():
-        # Skip any remaining stashed entries (cleanup from old implementation)
         if cl_name.endswith('_stashed'):
             continue
+
+        for f in files:
+            try:
+                abs_path = (git_root / f).resolve()
+                assigned_files.add(abs_path.relative_to(git_root).as_posix())
+            except (ValueError, OSError) as error:
+                print(f"Error resolving path: {error}")
 
         if selected_names is not None and cl_name not in selected_names:
             continue
 
-        if files:  # Only show non-empty changelists
+        if files:
             print(f"{cl_name}:")
             shown_any = True
             for file in files:
                 print(clutil_format_file_status(file, status_map, git_root, use_color))
-
-            # Track assigned files
-            for f in files:
-                try:
-                    abs_path = (git_root / f).resolve()
-                    rel_path = abs_path.relative_to(git_root).as_posix()
-                    assigned_files.add(rel_path)
-                except (ValueError, OSError) as error:
-                    print(f"Error resolving path: {error}")
 
     return shown_any, assigned_files
 

--- a/git-cl
+++ b/git-cl
@@ -56,7 +56,7 @@ Single file, zero dependencies beyond Python 3.9+ and Git.
 Cross-platform: Unix (fcntl) and Windows (msvcrt) file locking.
 """
 
-__version__ = "1.1.7"
+__version__ = "1.1.8"
 
 import argparse
 import datetime

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = git-changelists
-version = 1.1.7
+version = 1.1.8
 author = Bjoern Hendrik Fock
 description = Git subcommand for named changelist support. Group working directory files by intent, then stage, commit, or branch by changelist.
 long_description = file: README.md

--- a/tests/test_basic_add_status.py
+++ b/tests/test_basic_add_status.py
@@ -197,6 +197,56 @@ def run_tests(repo: TestRepo):
     repo.assert_equal(output_st, output_status,
                        "'git cl st' and 'git cl status' produce identical output")
 
+    # =================================================================
+    # Test: Filtering does not leak other changelists into No Changelist
+    # =================================================================
+    # Regression: `git cl st <name> --include-no-cl` previously listed
+    # files belonging to other (filtered-out) changelists under
+    # "No Changelist". Assigned-file tracking was skipped for changelists
+    # that weren't displayed, so their files looked unassigned. The leak
+    # was not specific to untracked files — a tracked modification leaked
+    # too, so we check both.
+
+    repo.section("Filtering does not leak other changelists into No Changelist")
+
+    repo.run("git cl delete --all")
+
+    # Two tracked files, committed then modified
+    repo.write_file("leak-a.txt", "a")
+    repo.write_file("leak-b.txt", "b")
+    repo.run("git add leak-a.txt leak-b.txt")
+    repo.run(["git", "commit", "--quiet", "-m", "Add leak-test files"])
+    repo.write_file("leak-a.txt", "a modified")   # [ M] tracked, in list1
+    repo.write_file("leak-b.txt", "b modified")   # [ M] tracked, in list2
+
+    # An untracked file for list2, plus a genuinely unassigned untracked
+    # file that SHOULD appear under No Changelist.
+    repo.write_file("leak-c.txt", "c")            # [??] untracked, in list2
+    repo.write_file("unassigned.txt", "u")        # [??] untracked, no changelist
+
+    repo.run("git cl add list1 leak-a.txt")
+    repo.run("git cl add list2 leak-b.txt leak-c.txt")
+
+    output = repo.run("git cl st list1 --include-no-cl")
+
+    # list1 (the filtered changelist) is shown with its file
+    repo.assert_in("list1:", output, "filtered changelist list1 is shown")
+    repo.assert_in("leak-a.txt", output, "list1's file is shown")
+
+    # The genuinely unassigned file appears under No Changelist
+    repo.assert_in("No Changelist:", output, "No Changelist section shown")
+    repo.assert_in("unassigned.txt", output,
+                    "genuinely unassigned file shown under No Changelist")
+
+    # list2 is filtered out, so neither its tracked nor its untracked file
+    # should appear anywhere — if either does, it has leaked into No Changelist.
+    repo.assert_not_in("leak-b.txt", output,
+                        "tracked file from filtered-out list2 does not leak")
+    repo.assert_not_in("leak-c.txt", output,
+                        "untracked file from filtered-out list2 does not leak")
+
+    repo.run("git cl delete --all")
+
 
 # =================================================================
 # Entry point


### PR DESCRIPTION
## Problem

When filtering `git cl st` by changelist name with `--include-no-cl`, files belonging to *other* (filtered-out) changelists were incorrectly listed under "No Changelist".

For example, with `leak-a.txt` in `list1` and `leak-b.txt` in `list2`:

```
git cl st list1 --include-no-cl
```

showed `leak-b.txt` under "No Changelist", even though it is assigned to `list2`.

## Cause

`clutil_show_active_changelists` only recorded a file as assigned when its changelist was actually displayed. The bookkeeping that populates `assigned_files` sat *after* the `selected_names` filter, so files in changelists that weren't shown never got recorded — and the "No Changelist" section, which lists everything not in `assigned_files`, then treated them as unassigned.

The bug was **not** specific to untracked files: a tracked modification (`[ M]`) in a filtered-out changelist leaked the same way. Untracked files just made it more noticeable.

## Fix

Move the `assigned_files` bookkeeping ahead of the display filter, so all assignments are recorded regardless of which changelists are shown. Display remains filtered; only the accounting is now complete.

## Test

Adds a regression test in `test_basic_add_status.py` that sets up two changelists, filters by one with `--include-no-cl`, and asserts that:

- the filtered changelist and its file are shown,
- a genuinely unassigned file does appear under "No Changelist",
- files from the filtered-out changelist (both a tracked `[ M]` and an untracked `[??]`) do **not** leak in.

Verified failing against the previous code and passing with the fix.