### PR TITLE
Fix: stash message could diverge from git's actual stash

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,8 +9,8 @@ url: "https://github.com/BHFock/git-cl"
 repository-code: "https://github.com/BHFock/git-cl"
 license: BSD-3-Clause
 doi: "10.5281/zenodo.18722077"
-version: "1.1.9"
-date-released: "2026-05-29"
+version: "1.1.10"
+date-released: "2026-05-30"
 abstract: >-
   git-cl is a command-line tool that brings changelist support to Git.
   It introduces a pre-staging layer that allows developers to partition

--- a/git-cl
+++ b/git-cl
@@ -1584,6 +1584,8 @@ def clutil_save_stash_metadata_atomic(
 
     Args:
         name: Changelist name
+        stash_message: Pre-generated unique stash message (shared with the
+            git stash push call)
         stash_ref: Git stash reference
         files: Files in the changelist
         file_categories: Categorized files

--- a/git-cl
+++ b/git-cl
@@ -56,7 +56,7 @@ Single file, zero dependencies beyond Python 3.9+ and Git.
 Cross-platform: Unix (fcntl) and Windows (msvcrt) file locking.
 """
 
-__version__ = "1.1.9"
+__version__ = "1.1.10"
 
 import argparse
 import datetime

--- a/git-cl
+++ b/git-cl
@@ -1470,6 +1470,7 @@ def clutil_prepare_files_for_git_stash(
 
 def clutil_execute_git_stash(
     name: str,
+    stash_message: str,
     files_for_git: list[str],
     untracked_files_for_git: list[str]
 ) -> str:
@@ -1477,7 +1478,9 @@ def clutil_execute_git_stash(
     Execute the git stash command.
 
     Args:
-        name: Changelist name
+        name: Changelist name (used to locate the created stash)
+        stash_message: Pre-generated unique stash message, shared with the
+            metadata save so the two can never diverge across a second boundary
         files_for_git: Files to stash
         untracked_files_for_git: Untracked files that were temporarily added
 
@@ -1487,7 +1490,6 @@ def clutil_execute_git_stash(
     Raises:
         subprocess.CalledProcessError: If stash fails
     """
-    stash_message = clutil_create_unique_stash_message(name)
 
     try:
         cmd = ["git", "stash", "push", "-m", stash_message, "--"] + files_for_git
@@ -1532,7 +1534,7 @@ def clutil_execute_git_stash(
 
 
 def clutil_build_stash_metadata(
-    name: str,
+    stash_message: str,
     stash_ref: str,
     files: list[str],
     file_categories: dict[str, list[str]],
@@ -1542,7 +1544,8 @@ def clutil_build_stash_metadata(
     Build stash metadata dictionary.
 
     Args:
-        name: Changelist name
+        stash_message: Pre-generated unique stash message — the same string
+            passed to `git stash push`, so metadata and git never diverge
         stash_ref: Git stash reference
         files: Files in the changelist
         file_categories: Categorized files
@@ -1551,8 +1554,6 @@ def clutil_build_stash_metadata(
     Returns:
         Dictionary containing stash metadata
     """
-    stash_message = clutil_create_unique_stash_message(name)
-
     return {
         "stash_ref": stash_ref,
         "stash_message": stash_message,
@@ -1571,6 +1572,7 @@ def clutil_build_stash_metadata(
 # pylint: disable-next=too-many-arguments
 def clutil_save_stash_metadata_atomic(
     name: str,
+    stash_message: str,
     stash_ref: str,
     files: list[str],
     file_categories: dict[str, list[str]],
@@ -1595,7 +1597,7 @@ def clutil_save_stash_metadata_atomic(
 
     # Build stash metadata
     stash_metadata = clutil_build_stash_metadata(
-        name, stash_ref, files, file_categories, current_branch
+        stash_message, stash_ref, files, file_categories, current_branch
     )
 
     # Save stash metadata
@@ -2967,12 +2969,19 @@ def cl_stash(args: argparse.Namespace, quiet: bool = False) -> None:
         stashable_files, file_categories, git_root, quiet=quiet
     )
 
+    # Generate the unique stash message once and thread it through both the
+    # git stash push and the metadata save. Generating it independently in
+    # each place risks the two timestamps differing across a second boundary,
+    # leaving cl-stashes.json with a message that doesn't match git's stash.
+    stash_message = clutil_create_unique_stash_message(name)
+
     # Execute git stash with safe directory handling
     try:
         with clutil_safe_stash_context(
                 git_root, files_for_git,
                 untracked_files_for_git) as (safe_files, safe_untracked_files):
-            stash_ref = clutil_execute_git_stash(name, safe_files,
+            stash_ref = clutil_execute_git_stash(name, stash_message,
+                                                 safe_files,
                                                  safe_untracked_files)
     except (subprocess.CalledProcessError, ValueError):
         return
@@ -2982,9 +2991,9 @@ def cl_stash(args: argparse.Namespace, quiet: bool = False) -> None:
 
     try:
         clutil_save_stash_metadata_atomic(
-            name, stash_ref, files, file_categories, changelists, stashes
+            name, stash_message, stash_ref, files,
+            file_categories, changelists, stashes
         )
-
         # Success! Print appropriate message based on context
         if not quiet:
             clutil_print_stash_success(name, stashable_files,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = git-changelists
-version = 1.1.9
+version = 1.1.10
 author = Bjoern Hendrik Fock
 description = Git subcommand for named changelist support. Group working directory files by intent, then stage, commit, or branch by changelist.
 long_description = file: README.md

--- a/tests/test_stash_message_consistency.py
+++ b/tests/test_stash_message_consistency.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""
+test_stash_message_consistency.py — Test that the stash message stored in
+cl-stashes.json matches the message git actually recorded.
+
+Regression guard for the bug where clutil_create_unique_stash_message was
+called twice for a single stash — once for `git stash push -m` and once when
+building the metadata — each call producing its own timestamp. If the two
+calls straddled a one-second boundary, the `stash_message` persisted in
+cl-stashes.json would not match the message stored in git's stash list.
+
+The fix generates the message once in cl_stash and threads it through both
+paths, so the two can never diverge.
+
+Note on determinism:
+    Because the divergence only occurs across a second boundary, this
+    integration test cannot *reliably* reproduce the original bug — both
+    timestamps almost always land in the same second, so even the buggy code
+    usually produced matching strings. The test's value is as an INVARIANT
+    GUARD: after the fix, the stored message is guaranteed to equal git's, and
+    this test pins that. It will catch any future regression that reintroduces
+    a second, independently generated message, or that lets the message format
+    drift between the two call sites. Deterministic reproduction of the timing
+    bug itself would require injecting a clock, which the subprocess-based test
+    framework does not support.
+
+Covers:
+    git cl stash <name>   — stored stash_message matches git's actual stash
+    git cl stash --all    — every stored message matches git's actual stash
+
+Run:
+    ./test_stash_message_consistency.py
+
+Export as shell walkthrough:
+    ./test_stash_message_consistency.py --export > walkthrough_stash_message.sh
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from test_helpers import TestRepo
+
+
+def run_tests(repo: TestRepo):
+
+    # =================================================================
+    # Setup: a tracked modification assigned to a changelist
+    # =================================================================
+
+    repo.section("Setup: a tracked modification in a changelist")
+
+    repo.write_file("file1.txt", "original")
+    repo.run("git add file1.txt")
+    repo.run(["git", "commit", "--quiet", "-m", "Add file1"])
+    repo.write_file("file1.txt", "modified")
+    repo.run("git cl add list-a file1.txt")
+
+    # =================================================================
+    # Test: single stash — stored message matches git's stash message
+    # =================================================================
+
+    repo.section("Single stash: stored message matches git's stash")
+
+    output = repo.run("git cl stash list-a")
+    repo.assert_exit_code(0, "git cl stash should succeed")
+
+    stash = repo.load_stash_json()
+    repo.assert_true("list-a" in stash,
+                     "list-a recorded in stash metadata")
+
+    stored_msg = stash["list-a"].get("stash_message", "")
+    repo.assert_true(
+        stored_msg.startswith("git-cl-stash:list-a:"),
+        "stored message carries the expected git-cl-stash prefix")
+
+    # The invariant: the message persisted in cl-stashes.json must be the
+    # exact message git recorded for the stash. `git stash list` shows the
+    # custom -m message, so the stored string must appear verbatim within it.
+    git_stash_list = repo.run("git stash list")
+    repo.assert_in(
+        stored_msg, git_stash_list,
+        "stored stash_message matches git's actual stash list entry")
+
+    # =================================================================
+    # Test: stash --all — every stored message matches git's
+    # =================================================================
+    # Exercises the loop path (clutil_stash_all_changelists -> cl_stash per
+    # changelist), confirming each metadata message lines up with git.
+
+    repo.section("stash --all: every stored message matches git")
+
+    # Restore the first changelist so we have a clean slate.
+    repo.run("git cl unstash list-a")
+
+    repo.write_file("file2.txt", "original2")
+    repo.run("git add file2.txt")
+    repo.run(["git", "commit", "--quiet", "-m", "Add file2"])
+
+    repo.write_file("file1.txt", "mod1")
+    repo.write_file("file2.txt", "mod2")
+    repo.run("git cl add list-a file1.txt")
+    repo.run("git cl add list-b file2.txt")
+
+    output = repo.run("git cl stash --all")
+    repo.assert_exit_code(0, "git cl stash --all should succeed")
+
+    stash = repo.load_stash_json()
+    git_stash_list = repo.run("git stash list")
+
+    for name in ("list-a", "list-b"):
+        repo.assert_true(name in stash, f"{name} recorded in stash metadata")
+        msg = stash[name].get("stash_message", "")
+        repo.assert_true(
+            msg.startswith(f"git-cl-stash:{name}:"),
+            f"{name}: stored message carries the expected prefix")
+        repo.assert_in(
+            msg, git_stash_list,
+            f"{name}: stored stash_message matches git's actual stash entry")
+
+
+# =================================================================
+# Entry point
+# =================================================================
+
+if __name__ == "__main__":
+
+    if "--help" in sys.argv:
+        print("Usage: ./test_stash_message_consistency.py [--export]\n")
+        print("Options:")
+        print("  --export   Print a shell walkthrough instead of test output.")
+        print("  --help     Show this message.")
+        sys.exit(0)
+
+    export_mode = "--export" in sys.argv
+
+    with TestRepo(quiet=export_mode) as repo:
+        run_tests(repo)
+        if export_mode:
+            print(repo.export_shell(
+                "git-cl walkthrough: stash message consistency"))


### PR DESCRIPTION
### Problem

`clutil_create_unique_stash_message` embeds a fresh timestamp on each call, and it was invoked twice for a single stash — once inside `clutil_execute_git_stash` (the message passed to `git stash push -m`) and again inside `clutil_build_stash_metadata` (the message persisted in `cl-stashes.json`). If the two calls straddled a one-second boundary, the `stash_message` recorded in metadata would not match the message git actually stored.

The mismatch was latent rather than visible: every stash lookup uses the `git-cl-stash:<name>:` substring rather than the full message, so the divergent timestamp was never compared. The inconsistent field was a trap for any future code — or a GUI integration — that trusted it.

### Fix

Generate the unique message once in `cl_stash` and thread it through both paths, so the string passed to `git stash push` and the string saved to `cl-stashes.json` are guaranteed identical.

This touches four functions:

- `cl_stash` — generates the message once and passes it onward
- `clutil_execute_git_stash` — takes the message as a parameter instead of generating its own
- `clutil_save_stash_metadata_atomic` — threads the message through
- `clutil_build_stash_metadata` — takes the message as a parameter; its `name` argument is dropped, since it was only used to generate the message

`clutil_create_unique_stash_message` is unchanged and now has a single caller.

### Tests

Adds `test_stash_message_consistency.py`, asserting that the `stash_message` stored in `cl-stashes.json` matches the message in git's stash list — for both a single `git cl stash` and `git cl stash --all`.

A note on determinism: the divergence only occurs across a second boundary, which a subprocess-based integration test cannot reliably reproduce (both timestamps almost always land in the same second). The test therefore acts as an invariant guard — after the fix the stored message is guaranteed to match git's, and the test pins that, catching any future regression that reintroduces a second independently generated message or lets the format drift between the two call sites.