### PR TITLE
Fail fast in git cl br when a changelist is not fully stashable (#51)

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -9,8 +9,8 @@ url: "https://github.com/BHFock/git-cl"
 repository-code: "https://github.com/BHFock/git-cl"
 license: BSD-3-Clause
 doi: "10.5281/zenodo.18722077"
-version: "1.1.11"
-date-released: "2026-05-30"
+version: "1.1.12"
+date-released: "2026-06-12"
 abstract: >-
   git-cl is a command-line tool that brings changelist support to Git.
   It introduces a pre-staging layer that allows developers to partition

--- a/git-cl
+++ b/git-cl
@@ -1060,18 +1060,23 @@ def clutil_rollback_stash(stash_ref: str, changelist_name: str) -> bool:
 
 
 def clutil_stash_all_changelists(changelists: dict[str, list[str]],
-                                 quiet: bool = False) -> None:
+                                 quiet: bool = False) -> tuple[int, int]:
     """
     Helper function to stash all active changelists.
 
     Args:
         changelists: Dictionary of active changelists
         quiet: If True, suppress verbose output for workflow contexts
+
+    Returns:
+        Tuple of (success_count, total) where total is the number of
+        non-empty changelists. Callers must compare the two to detect
+        partial failures (see issue #51).
     """
     if not changelists:
         if not quiet:
             print("No active changelists found.")
-        return
+        return 0, 0
 
     # Get current branch for tracking
     current_branch = clutil_get_current_branch()
@@ -1084,6 +1089,7 @@ def clutil_stash_all_changelists(changelists: dict[str, list[str]],
 
     # Sort changelists by name for predictable order
     sorted_changelists = sorted(changelists.items())
+    total = len([cl for cl, files in sorted_changelists if files])
 
     for cl_name, files in sorted_changelists:
         if not files:  # Skip empty changelists
@@ -1098,24 +1104,27 @@ def clutil_stash_all_changelists(changelists: dict[str, list[str]],
         temp_args.all = False
 
         try:
-            # Call cl_stash with quiet mode
-            cl_stash(temp_args, quiet=quiet)
-            success_count += 1
+            # Call cl_stash with quiet mode. cl_stash reports its own
+            # errors and returns False on failure, so only count real
+            # successes here (previously every call was counted).
+            if cl_stash(temp_args, quiet=quiet):
+                success_count += 1
+            else:
+                print(f"Failed to stash changelist '{cl_name}'.")
         except (OSError, subprocess.CalledProcessError,
                 json.JSONDecodeError) as error:
             print(f"Failed to stash '{cl_name}': {error}")
             continue
 
     if not quiet:
-        print(
-            f"\nStashed {success_count}/"
-            f"{len([cl for cl, files in sorted_changelists if files])} "
-            "changelists successfully."
-        )
+        print(f"\nStashed {success_count}/{total} "
+              "changelists successfully.")
         if success_count > 0:
             print("Working directory should now be clean for branch operations.")
             print("Use 'git cl unstash <changelist>' to restore individual "
                   "changelists to feature branches.")
+
+    return success_count, total
 
 
 def clutil_validate_stash_preconditions(
@@ -1558,23 +1567,27 @@ def clutil_handle_stash_failure(
 def clutil_unstash_all_changelists(
     stashes: dict[str, dict],
     force: bool = False
-) -> None:
+) -> tuple[int, int]:
     """
     Helper function to unstash all stashed changelists.
 
     Args:
         stashes: Dictionary of stashed changelists
         force: Whether to force unstash despite conflicts
+
+    Returns:
+        Tuple of (success_count, total). Callers must compare the two
+        to detect partial failures.
     """
     if not stashes:
         print("No stashed changelists found.")
-        return
+        return 0, 0
 
     current_branch = clutil_get_current_branch()
     if not current_branch:
         print("Error: Cannot unstash --all while in detached HEAD state.")
         print("Switch to a branch first: git checkout -b <branch-name>")
-        return
+        return 0, len(stashes)
 
     print(f"Unstashing all changelists to branch '{current_branch}':")
     success_count = 0
@@ -1592,9 +1605,13 @@ def clutil_unstash_all_changelists(
         temp_args.all = False
 
         try:
-            # Note: cl_unstash is called later in the module
-            cl_unstash(temp_args)
-            success_count += 1
+            # Note: cl_unstash is called later in the module. It reports
+            # its own errors and returns False on failure, so only count
+            # real successes here.
+            if cl_unstash(temp_args):
+                success_count += 1
+            else:
+                print(f"Failed to unstash changelist '{stash_name}'.")
         except (OSError,
                 subprocess.CalledProcessError, json.JSONDecodeError) as error:
             print(f"Failed to unstash '{stash_name}': {error}")
@@ -1602,6 +1619,7 @@ def clutil_unstash_all_changelists(
 
     print(f"\nUnstashed {success_count}/{len(stash_items)} "
           f"changelists successfully.")
+    return success_count, len(stash_items)
 
 
 def clutil_resolve_unstash_name(name: str) -> tuple[str, str]:
@@ -2180,6 +2198,64 @@ def clutil_check_unassigned_changes(changelists: dict,
             if file_path not in assigned_files and status != "??"]
 
 
+def clutil_validate_changelists_stashable(
+        changelists: dict[str, list[str]],
+        git_root: Path,
+        status_map: dict[str, str]) -> dict[str, list[str]]:
+    """
+    Pre-flight check that every changelist contains only stashable files.
+
+    'git cl br' must stash ALL active changelists before creating the
+    branch. cl_stash deliberately refuses a changelist that contains
+    clean files, staged-only modifications, or no stashable changes at
+    all. Without this check, such a changelist would abort the workflow
+    halfway through: some changelists stashed, others not, and the new
+    branch created on top of a dirty working directory (issue #51).
+    This function reports all problems up front, before any state is
+    mutated, so the user can clean up first.
+
+    Args:
+        changelists: Active (non-empty) changelists to validate
+        git_root: Git repository root
+        status_map: Precomputed status map from
+                    clutil_get_file_status_map(show_all=True)
+
+    Returns:
+        Mapping of changelist name to a list of human-readable problem
+        descriptions. An empty dict means every changelist is fully
+        stashable and the branch workflow may proceed.
+    """
+    problems: dict[str, list[str]] = {}
+
+    for name, files in sorted(changelists.items()):
+        if not files:
+            continue
+
+        existing_files, missing_files = clutil_prepare_stash_files(
+            files, git_root)
+        file_categories, stashable_files, unstashable_files = (
+            clutil_categorize_files_for_stash(
+                existing_files, missing_files, status_map, git_root))
+
+        messages = []
+        for file_path in file_categories['clean_files']:
+            messages.append(f"{file_path} (clean - no changes to stash)")
+        for file_path in file_categories['staged_modifications']:
+            messages.append(f"{file_path} (only staged changes)")
+        known_unstashable = (set(file_categories['clean_files'])
+                             | set(file_categories['staged_modifications']))
+        for file_path in unstashable_files:
+            if file_path not in known_unstashable:
+                messages.append(f"{file_path} (not stashable)")
+        if not unstashable_files and not stashable_files:
+            messages.append("(changelist has no stashable changes)")
+
+        if messages:
+            problems[name] = messages
+
+    return problems
+
+
 def clutil_create_branch(branch_name: str,
                          base_branch: str, current_branch: str) -> None:
     """Create new branch from base."""
@@ -2192,13 +2268,13 @@ def clutil_create_branch(branch_name: str,
         subprocess.run(["git", "checkout", "-b", branch_name], check=True)
 
 
-def clutil_unstash_changelist(changelist_name: str) -> None:
-    """Unstash specific changelist."""
+def clutil_unstash_changelist(changelist_name: str) -> bool:
+    """Unstash specific changelist. Returns True on success."""
     temp_unstash_args = argparse.Namespace()
     temp_unstash_args.name = changelist_name
     temp_unstash_args.force = False
     temp_unstash_args.all = False
-    cl_unstash(temp_unstash_args, quiet=True)  # Add quiet=True here
+    return cl_unstash(temp_unstash_args, quiet=True)
 
 
 def clutil_handle_branch_creation_failure() -> None:
@@ -2773,7 +2849,7 @@ def cl_commit(args: argparse.Namespace) -> None:
         print(f"Kept changelist '{name}'")
 
 
-def cl_stash(args: argparse.Namespace, quiet: bool = False) -> None:
+def cl_stash(args: argparse.Namespace, quiet: bool = False) -> bool:
     """
     Stash all unstaged changes for files in specified changelist(s).
     Supports --all to stash all active changelists.
@@ -2788,14 +2864,20 @@ def cl_stash(args: argparse.Namespace, quiet: bool = False) -> None:
         args: argparse.Namespace with 'name'
               (or None for --all), 'all' attributes.
         quiet: If True, suppress verbose output for workflow contexts
+
+    Returns:
+        True if the stash succeeded (for --all: all changelists were
+        stashed), False otherwise. Callers such as cl_branch rely on
+        this to detect failures that are otherwise only printed.
     """
     changelists = clutil_load()
     stashes = clutil_load_stashes()
 
     # Handle --all flag
     if getattr(args, 'all', False):
-        clutil_stash_all_changelists(changelists, quiet=quiet)
-        return
+        success_count, total = clutil_stash_all_changelists(changelists,
+                                                            quiet=quiet)
+        return success_count == total
 
     # Handle single changelist stash
     name = args.name
@@ -2804,7 +2886,7 @@ def cl_stash(args: argparse.Namespace, quiet: bool = False) -> None:
     error_msg = clutil_validate_stash_preconditions(name, changelists, stashes)
     if error_msg:
         print(error_msg)
-        return
+        return False
 
     git_root = clutil_get_git_root()
     files = changelists[name]
@@ -2816,7 +2898,7 @@ def cl_stash(args: argparse.Namespace, quiet: bool = False) -> None:
     status_map = clutil_get_file_status_map(show_all=True)
 
     if clutil_refuse_on_merge_conflict(status_map, "stash"):
-        return
+        return False
 
     categorization = clutil_categorize_files_for_stash(
         existing_files, missing_files, status_map, git_root
@@ -2826,12 +2908,12 @@ def cl_stash(args: argparse.Namespace, quiet: bool = False) -> None:
     # Report categorization and check if we can proceed (suppress in quiet mode)
     if not clutil_report_stash_categorization(file_categories,
                                               unstashable_files, name, quiet=quiet):
-        return
+        return False
 
     if not stashable_files:
         if not quiet:
             print(f"No stashable files found in changelist '{name}'.")
-        return
+        return False
 
     # Prepare files for git stash command
     current_branch = clutil_get_current_branch()
@@ -2862,7 +2944,7 @@ def cl_stash(args: argparse.Namespace, quiet: bool = False) -> None:
                                                  safe_files,
                                                  safe_untracked_files)
     except (subprocess.CalledProcessError, ValueError):
-        return
+        return False
 
     # Save metadata atomically
     original_changelists = changelists.copy()
@@ -2876,14 +2958,16 @@ def cl_stash(args: argparse.Namespace, quiet: bool = False) -> None:
         if not quiet:
             clutil_print_stash_success(name, stashable_files,
                                        file_categories, current_branch)
+        return True
 
     except (OSError, subprocess.CalledProcessError,
             json.JSONDecodeError) as error:
         clutil_handle_stash_failure(error, name, stash_ref,
                                     original_changelists, stashes)
+        return False
 
 
-def cl_unstash(args: argparse.Namespace, quiet: bool = False) -> None:
+def cl_unstash(args: argparse.Namespace, quiet: bool = False) -> bool:
     """
     Restore a stashed changelist to the working directory.
     Enforces clean branch workflow by default.
@@ -2893,18 +2977,24 @@ def cl_unstash(args: argparse.Namespace, quiet: bool = False) -> None:
         args: argparse.Namespace with 'name' (or None for --all),
             'force', and 'all' attributes.
         quiet: If True, suppress verbose output for workflow contexts
+
+    Returns:
+        True if the unstash succeeded (for --all: all changelists were
+        unstashed), False otherwise. Callers such as cl_branch rely on
+        this to detect failures that are otherwise only printed.
     """
     stashes = clutil_load_stashes()
     changelists = clutil_load()
 
     status_map = clutil_get_file_status_map(show_all=True)
     if clutil_refuse_on_merge_conflict(status_map, "unstash"):
-        return
+        return False
 
     # Handle --all flag
     if getattr(args, 'all', False):
-        clutil_unstash_all_changelists(stashes, getattr(args, 'force', False))
-        return
+        success_count, total = clutil_unstash_all_changelists(
+            stashes, getattr(args, 'force', False))
+        return success_count == total
 
     # Handle single changelist unstash
     name = args.name
@@ -2917,7 +3007,7 @@ def cl_unstash(args: argparse.Namespace, quiet: bool = False) -> None:
     )
     if error_msg:
         print(error_msg)
-        return
+        return False
 
     stash_ref = stash_data["stash_ref"]
     files = stash_data["files"]
@@ -2927,20 +3017,21 @@ def cl_unstash(args: argparse.Namespace, quiet: bool = False) -> None:
     if not clutil_check_and_report_conflicts(files, git_root, base_name,
                                              getattr(args, 'force', False),
                                              quiet=quiet):
-        return
+        return False
 
     # Verify stash still exists and update reference
     stash_ref = clutil_verify_and_update_stash_ref(base_name, stash_ref)
     if not stash_ref:
-        return
+        return False
 
     # Apply the stash (suppress verbose output in quiet mode)
     if not clutil_apply_stash(stash_ref, base_name, quiet=quiet):
-        return
+        return False
 
     # Success - update metadata (suppress verbose output in quiet mode)
     clutil_update_unstash_metadata(base_name, stash_key,
                                    files, changelists, stashes, quiet=quiet)
+    return True
 
 
 def cl_branch(args: argparse.Namespace) -> None:
@@ -3002,8 +3093,34 @@ def cl_branch(args: argparse.Namespace) -> None:
     # Determine base branch
     base_branch = getattr(args, 'from_branch', None) or current_branch
 
-    # Count active changelists for summary
+    # Collect active changelists for the workflow
     active_changelists = {name: files for name, files in changelists.items() if files}
+
+    # Pre-flight: every active changelist must be fully stashable.
+    # cl_stash refuses changelists containing clean or staged-only files,
+    # so a single such changelist would otherwise abort the workflow
+    # halfway through and leave the repo inconsistent (issue #51).
+    # Fail fast here, before any state is mutated.
+    status_map = clutil_get_file_status_map(show_all=True)
+    problems = clutil_validate_changelists_stashable(
+        active_changelists, git_root, status_map)
+    if problems:
+        print("Error: Not all changelists can be stashed cleanly:")
+        for cl_name, messages in sorted(problems.items()):
+            print(f"  {cl_name}:")
+            for message in messages:
+                print(f"    {message}")
+        print("\n'git cl br' must stash every active changelist before "
+              "creating the branch.")
+        print("Clean up the changelists above first, for example:")
+        print("  - Remove clean files from a changelist: git cl rm <files>")
+        print("  - Or commit them: git cl commit <changelist> -m '...'")
+        print("  - Move staged-only changes back to unstaged: "
+              "git cl unstage <changelist>")
+        print("  - Delete obsolete changelists: git cl delete <changelist>")
+        print("\nThen retry: git cl br "
+              f"{changelist_name} {branch_name}")
+        return
 
     print(f"Creating branch '{branch_name}' with changelist '{changelist_name}'")
     if len(active_changelists) > 1:
@@ -3011,11 +3128,22 @@ def cl_branch(args: argparse.Namespace) -> None:
 
     # Step 1: Stash all active changelists (quietly)
     try:
-        clutil_stash_all_changelists(active_changelists, quiet=True)
+        success_count, total = clutil_stash_all_changelists(
+            active_changelists, quiet=True)
     except (subprocess.CalledProcessError,
             OSError, json.JSONDecodeError) as error:
         print(f"Error during stash operation: {error}")
         print("Branch creation aborted.")
+        return
+
+    # The pre-flight check should make this unreachable, but git stash
+    # can still fail for other reasons (I/O errors, hooks, ...). Never
+    # create the branch on top of a partially stashed working directory.
+    if success_count != total:
+        print(f"Error: Only {success_count}/{total} changelists could "
+              "be stashed.")
+        print("Branch creation aborted. Restoring stashed changelists...")
+        clutil_handle_branch_creation_failure()
         return
 
     # Step 2: Create the new branch
@@ -3030,7 +3158,11 @@ def cl_branch(args: argparse.Namespace) -> None:
 
     # Step 3: Unstash the target changelist (quietly)
     try:
-        clutil_unstash_changelist(changelist_name)
+        if not clutil_unstash_changelist(changelist_name):
+            print(f"Error: Branch '{branch_name}' was created but "
+                  f"restoring changelist '{changelist_name}' failed.")
+            print(f"Try manually: git cl unstash {changelist_name}")
+            return
 
         # Single success message
         file_count = len(changelists.get(changelist_name, []))
@@ -3040,7 +3172,7 @@ def cl_branch(args: argparse.Namespace) -> None:
     except (subprocess.CalledProcessError,
             OSError, json.JSONDecodeError) as error:
         print(f"Error unstashing changelist: {error}")
-        print(f"Branch '{branch_name}' was created but"
+        print(f"Branch '{branch_name}' was created but "
               "changelist restore failed.")
         print(f"Try manually: git cl unstash {changelist_name}")
 

--- a/git-cl
+++ b/git-cl
@@ -2214,6 +2214,14 @@ def clutil_validate_changelists_stashable(
     This function reports all problems up front, before any state is
     mutated, so the user can clean up first.
 
+    Additionally, when more than one changelist is stashed, no file may
+    have a staged component (e.g. 'A ' staged additions): git builds a
+    pathspec-limited stash from the FULL index, so any staged file —
+    even one belonging to another changelist — leaks into every stash
+    created while it is staged, and reappears when that stash is
+    applied. Staged files must be removed from the index first, e.g.
+    with 'git cl unstage <changelist>' (issue #51).
+
     Args:
         changelists: Active (non-empty) changelists to validate
         git_root: Git repository root
@@ -2227,10 +2235,10 @@ def clutil_validate_changelists_stashable(
     """
     problems: dict[str, list[str]] = {}
 
-    for name, files in sorted(changelists.items()):
-        if not files:
-            continue
+    active = {name: files for name, files in changelists.items() if files}
+    multiple_changelists = len(active) > 1
 
+    for name, files in sorted(active.items()):
         existing_files, missing_files = clutil_prepare_stash_files(
             files, git_root)
         file_categories, stashable_files, unstashable_files = (
@@ -2249,6 +2257,19 @@ def clutil_validate_changelists_stashable(
                 messages.append(f"{file_path} (not stashable)")
         if not unstashable_files and not stashable_files:
             messages.append("(changelist has no stashable changes)")
+
+        # Staged components leak into every pathspec stash created while
+        # they sit in the index (git records the full index state). With
+        # a single changelist there is nothing to leak into; with several
+        # the file would silently reappear when another stash is applied.
+        if multiple_changelists:
+            for stored_path, abs_path in existing_files:
+                rel = abs_path.relative_to(git_root).as_posix()
+                status = status_map.get(rel, "  ")
+                if status[0] not in (' ', '?'):
+                    messages.append(
+                        f"{stored_path} (staged - remove from index "
+                        "before stashing)")
 
         if messages:
             problems[name] = messages
@@ -3112,11 +3133,14 @@ def cl_branch(args: argparse.Namespace) -> None:
                 print(f"    {message}")
         print("\n'git cl br' must stash every active changelist before "
               "creating the branch.")
+        print("Staged files must be removed from the index first: git "
+              "builds each stash\nfrom the full index, so staged files "
+              "leak into other changelists' stashes.")
         print("Clean up the changelists above first, for example:")
+        print("  - Remove staged files from the index: "
+              "git cl unstage <changelist>")
         print("  - Remove clean files from a changelist: git cl rm <files>")
         print("  - Or commit them: git cl commit <changelist> -m '...'")
-        print("  - Move staged-only changes back to unstaged: "
-              "git cl unstage <changelist>")
         print("  - Delete obsolete changelists: git cl delete <changelist>")
         print("\nThen retry: git cl br "
               f"{changelist_name} {branch_name}")

--- a/git-cl
+++ b/git-cl
@@ -56,7 +56,7 @@ Single file, zero dependencies beyond Python 3.9+ and Git.
 Cross-platform: Unix (fcntl) and Windows (msvcrt) file locking.
 """
 
-__version__ = "1.1.11"
+__version__ = "1.1.12"
 
 import argparse
 import datetime

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = git-changelists
-version = 1.1.11
+version = 1.1.12
 author = Bjoern Hendrik Fock
 description = Git subcommand for named changelist support. Group working directory files by intent, then stage, commit, or branch by changelist.
 long_description = file: README.md

--- a/tests/test_branch_preflight.py
+++ b/tests/test_branch_preflight.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""
+test_branch_preflight.py — Test pre-flight validation of 'git cl branch'.
+
+Covers (issue #51):
+    git cl branch with a changelist containing clean files     — fails fast
+    git cl branch with staged files in multiple changelists    — fails fast
+    git cl branch after cleaning up the changelists            — succeeds
+    git cl branch with a single changelist with staged files   — succeeds
+
+What you'll learn:
+    - 'git cl branch' must stash EVERY active changelist before creating
+      the branch, so every changelist must be fully stashable
+    - Clean (unmodified) files in a changelist block the workflow: the
+      command aborts before mutating any state instead of leaving the
+      repository half-stashed on a new branch
+    - Staged files block the workflow when more than one changelist is
+      involved: git records the full index in every pathspec stash, so
+      staged files would leak into other changelists' stashes and
+      reappear when those stashes are applied
+    - The error messages explain how to clean up (git cl rm,
+      git cl unstage, git cl commit, git cl delete)
+
+Run:
+    ./test_branch_preflight.py
+
+Export as shell walkthrough:
+    ./test_branch_preflight.py --export > walkthrough_branch_preflight.sh
+"""
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent))
+from test_helpers import TestRepo
+
+
+def run_tests(repo: TestRepo):
+
+    # =================================================================
+    # Setup: tracked files with an initial commit
+    # =================================================================
+
+    repo.section("Setup: create files with an initial commit")
+
+    repo.write_file("mod_a.txt", "a")
+    repo.write_file("clean_b.txt", "b")
+    repo.write_file("mod_c.txt", "c")
+    repo.run("git add mod_a.txt clean_b.txt mod_c.txt")
+    repo.run(["git", "commit", "--quiet", "-m", "Add files"])
+
+    default_branch = repo.get_current_branch()
+
+    # =================================================================
+    # Test: changelist with a clean file blocks the workflow (issue #51)
+    # =================================================================
+    # Changelist A holds one modified and one clean file. cl_stash
+    # refuses changelists containing clean files, so 'git cl branch'
+    # must abort BEFORE stashing anything or creating the branch.
+
+    repo.section("Changelist with clean file blocks branch creation")
+
+    repo.write_file("mod_a.txt", "a modified")
+    repo.write_file("mod_c.txt", "c modified")
+    repo.run("git cl add A mod_a.txt clean_b.txt")
+    repo.run("git cl add B mod_c.txt")
+
+    output = repo.run("git cl branch B")
+    repo.assert_in("clean_b.txt", output,
+                   "error message names the clean file")
+    repo.assert_in("clean", output,
+                   "error message explains the file has no changes")
+    repo.assert_in("git cl rm", output,
+                   "error message suggests 'git cl rm' cleanup")
+
+    # Nothing must have changed: no branch, no stashes, both
+    # changelists still active, modifications still in place
+    branch = repo.get_current_branch()
+    repo.assert_equal(default_branch, branch,
+                      "still on the original branch")
+
+    stash_list = repo.run("git stash list")
+    repo.assert_equal("", stash_list,
+                      "no git stashes were created")
+
+    cl = repo.load_cl_json()
+    repo.assert_true("A" in cl and "B" in cl,
+                     "both changelists still active")
+
+    stash = repo.load_stash_json()
+    repo.assert_true("A" not in stash and "B" not in stash,
+                     "no changelist was stashed")
+
+    repo.assert_equal("a modified", repo.read_file("mod_a.txt"),
+                      "mod_a.txt modifications untouched")
+    repo.assert_equal("c modified", repo.read_file("mod_c.txt"),
+                      "mod_c.txt modifications untouched")
+
+    # =================================================================
+    # Test: after removing the clean file, the workflow succeeds
+    # =================================================================
+
+    repo.section("After cleanup the branch workflow succeeds")
+
+    repo.run("git cl rm clean_b.txt")
+
+    output = repo.run("git cl branch B")
+    repo.assert_exit_code(0, "git cl branch should succeed after cleanup")
+
+    branch = repo.get_current_branch()
+    repo.assert_equal("B", branch, "now on branch 'B'")
+
+    cl = repo.load_cl_json()
+    repo.assert_true("B" in cl, "changelist B active on new branch")
+
+    repo.assert_equal("c modified", repo.read_file("mod_c.txt"),
+                      "mod_c.txt modifications present on new branch")
+
+    # Changelist A was stashed, so its modification must be gone
+    repo.assert_equal("a", repo.read_file("mod_a.txt"),
+                      "mod_a.txt reverted (changelist A stashed)")
+
+    stash = repo.load_stash_json()
+    repo.assert_true("A" in stash, "changelist A is stashed")
+
+    # =================================================================
+    # Test: staged files in multiple changelists block the workflow
+    # =================================================================
+    # Git builds pathspec-limited stashes from the FULL index, so a
+    # staged file leaks into every stash created while it is staged
+    # and would reappear when another changelist's stash is applied.
+
+    repo.section("Staged files in multiple changelists block the workflow")
+
+    # Clean up the previous scenario: restore the stashed changelist,
+    # revert all modifications and remove the changelists
+    repo.run("git cl unstash A --force")
+    repo.run("git checkout --quiet " + default_branch)
+    repo.run("git reset --quiet --hard HEAD")
+    repo.run("git cl delete --all")
+
+    repo.write_file("folder1/file1.txt", "f1")
+    repo.write_file("dddd", "d")
+    repo.run("git add folder1/file1.txt dddd")
+    repo.write_file("mod_a.txt", "a modified again")
+
+    repo.run("git cl add ok folder1/file1.txt")
+    repo.run("git cl add xxx dddd mod_a.txt")
+
+    output = repo.run("git cl branch ok")
+    repo.assert_in("staged", output,
+                   "error message mentions staged files")
+    repo.assert_in("git cl unstage", output,
+                   "error message suggests 'git cl unstage'")
+    repo.assert_in("dddd", output,
+                   "error message names the staged file dddd")
+    repo.assert_in("folder1/file1.txt", output,
+                   "error message names the staged file folder1/file1.txt")
+
+    branch = repo.get_current_branch()
+    repo.assert_equal(default_branch, branch,
+                      "still on the original branch")
+
+    stash_list = repo.run("git stash list")
+    repo.assert_equal("", stash_list,
+                      "no git stashes were created")
+
+    staged = repo.get_staged_files()
+    repo.assert_in("dddd", staged, "dddd still staged (state untouched)")
+
+    # =================================================================
+    # Test: after unstaging, the workflow succeeds without leaks
+    # =================================================================
+    # This is the leak scenario from issue #51: previously dddd
+    # reappeared (staged) on the new branch although it belongs to the
+    # stashed changelist xxx.
+
+    repo.section("After unstaging the workflow succeeds without leaks")
+
+    repo.run("git cl unstage ok")
+    repo.run("git cl unstage xxx")
+
+    output = repo.run("git cl branch ok")
+    repo.assert_exit_code(0, "git cl branch should succeed after unstaging")
+
+    branch = repo.get_current_branch()
+    repo.assert_equal("ok", branch, "now on branch 'ok'")
+
+    cl = repo.load_cl_json()
+    repo.assert_true("ok" in cl, "changelist ok active on new branch")
+    repo.assert_true(repo.file_exists("folder1/file1.txt"),
+                     "folder1/file1.txt restored on new branch")
+
+    # The crucial check: files of the stashed changelist xxx must NOT
+    # leak onto the new branch
+    repo.assert_true(not repo.file_exists("dddd"),
+                     "dddd did NOT leak onto the new branch")
+    repo.assert_equal("a", repo.read_file("mod_a.txt"),
+                      "mod_a.txt reverted (changelist xxx stashed)")
+
+    stash = repo.load_stash_json()
+    repo.assert_true("xxx" in stash, "changelist xxx is stashed")
+
+    # =================================================================
+    # Test: a single changelist with staged files still works
+    # =================================================================
+    # With only one changelist there is nothing the staged files could
+    # leak into, so the workflow must not be blocked.
+
+    repo.section("Single changelist with staged files still works")
+
+    # Clean up the previous scenario: restore the stashed changelist,
+    # revert everything (staged-new files become untracked and are
+    # removed by git clean) and delete the changelists
+    repo.run("git cl unstash xxx --force")
+    repo.run("git checkout --quiet " + default_branch)
+    repo.run("git reset --quiet --hard HEAD")
+    repo.run("git clean --quiet -fd")
+    repo.run("git cl delete --all")
+
+    repo.write_file("solo.txt", "solo")
+    repo.run("git add solo.txt")
+    repo.run("git cl add solo solo.txt")
+
+    output = repo.run("git cl branch solo")
+    repo.assert_exit_code(0,
+                          "git cl branch with single staged changelist "
+                          "should succeed")
+
+    branch = repo.get_current_branch()
+    repo.assert_equal("solo", branch, "now on branch 'solo'")
+
+    staged = repo.get_staged_files()
+    repo.assert_in("solo.txt", staged,
+                   "solo.txt restored as staged on the new branch")
+
+
+# =================================================================
+# Entry point
+# =================================================================
+
+if __name__ == "__main__":
+
+    if "--help" in sys.argv:
+        print("Usage: ./test_branch_preflight.py [--export]\n")
+        print("Options:")
+        print("  --export   Print a shell walkthrough instead of test output.")
+        print("  --help     Show this message.")
+        sys.exit(0)
+
+    export_mode = "--export" in sys.argv
+
+    with TestRepo(quiet=export_mode) as repo:
+        run_tests(repo)
+        if export_mode:
+            print(repo.export_shell("git-cl walkthrough: branch pre-flight"))

--- a/tests/test_branch_preflight.py
+++ b/tests/test_branch_preflight.py
@@ -54,7 +54,7 @@ def run_tests(repo: TestRepo):
     # =================================================================
     # Test: changelist with a clean file blocks the workflow (issue #51)
     # =================================================================
-    # Changelist A holds one modified and one clean file. cl_stash
+    # Changelist 'docs' holds one modified and one clean file. cl_stash
     # refuses changelists containing clean files, so 'git cl branch'
     # must abort BEFORE stashing anything or creating the branch.
 
@@ -62,10 +62,10 @@ def run_tests(repo: TestRepo):
 
     repo.write_file("mod_a.txt", "a modified")
     repo.write_file("mod_c.txt", "c modified")
-    repo.run("git cl add A mod_a.txt clean_b.txt")
-    repo.run("git cl add B mod_c.txt")
+    repo.run("git cl add docs mod_a.txt clean_b.txt")
+    repo.run("git cl add feature mod_c.txt")
 
-    output = repo.run("git cl branch B")
+    output = repo.run("git cl branch feature")
     repo.assert_in("clean_b.txt", output,
                    "error message names the clean file")
     repo.assert_in("clean", output,
@@ -84,11 +84,11 @@ def run_tests(repo: TestRepo):
                       "no git stashes were created")
 
     cl = repo.load_cl_json()
-    repo.assert_true("A" in cl and "B" in cl,
+    repo.assert_true("docs" in cl and "feature" in cl,
                      "both changelists still active")
 
     stash = repo.load_stash_json()
-    repo.assert_true("A" not in stash and "B" not in stash,
+    repo.assert_true("docs" not in stash and "feature" not in stash,
                      "no changelist was stashed")
 
     repo.assert_equal("a modified", repo.read_file("mod_a.txt"),
@@ -104,24 +104,25 @@ def run_tests(repo: TestRepo):
 
     repo.run("git cl rm clean_b.txt")
 
-    output = repo.run("git cl branch B")
+    output = repo.run("git cl branch feature")
     repo.assert_exit_code(0, "git cl branch should succeed after cleanup")
 
     branch = repo.get_current_branch()
-    repo.assert_equal("B", branch, "now on branch 'B'")
+    repo.assert_equal("feature", branch, "now on branch 'feature'")
 
     cl = repo.load_cl_json()
-    repo.assert_true("B" in cl, "changelist B active on new branch")
+    repo.assert_true("feature" in cl,
+                     "changelist 'feature' active on new branch")
 
     repo.assert_equal("c modified", repo.read_file("mod_c.txt"),
                       "mod_c.txt modifications present on new branch")
 
-    # Changelist A was stashed, so its modification must be gone
+    # Changelist 'docs' was stashed, so its modification must be gone
     repo.assert_equal("a", repo.read_file("mod_a.txt"),
-                      "mod_a.txt reverted (changelist A stashed)")
+                      "mod_a.txt reverted (changelist 'docs' stashed)")
 
     stash = repo.load_stash_json()
-    repo.assert_true("A" in stash, "changelist A is stashed")
+    repo.assert_true("docs" in stash, "changelist 'docs' is stashed")
 
     # =================================================================
     # Test: staged files in multiple changelists block the workflow
@@ -134,28 +135,28 @@ def run_tests(repo: TestRepo):
 
     # Clean up the previous scenario: restore the stashed changelist,
     # revert all modifications and remove the changelists
-    repo.run("git cl unstash A --force")
+    repo.run("git cl unstash docs --force")
     repo.run("git checkout --quiet " + default_branch)
     repo.run("git reset --quiet --hard HEAD")
     repo.run("git cl delete --all")
 
-    repo.write_file("folder1/file1.txt", "f1")
-    repo.write_file("dddd", "d")
-    repo.run("git add folder1/file1.txt dddd")
+    repo.write_file("src/new_a.txt", "new file a")
+    repo.write_file("new_b.txt", "new file b")
+    repo.run("git add src/new_a.txt new_b.txt")
     repo.write_file("mod_a.txt", "a modified again")
 
-    repo.run("git cl add ok folder1/file1.txt")
-    repo.run("git cl add xxx dddd mod_a.txt")
+    repo.run("git cl add feature-a src/new_a.txt")
+    repo.run("git cl add feature-b new_b.txt mod_a.txt")
 
-    output = repo.run("git cl branch ok")
+    output = repo.run("git cl branch feature-a")
     repo.assert_in("staged", output,
                    "error message mentions staged files")
     repo.assert_in("git cl unstage", output,
                    "error message suggests 'git cl unstage'")
-    repo.assert_in("dddd", output,
-                   "error message names the staged file dddd")
-    repo.assert_in("folder1/file1.txt", output,
-                   "error message names the staged file folder1/file1.txt")
+    repo.assert_in("new_b.txt", output,
+                   "error message names the staged file new_b.txt")
+    repo.assert_in("src/new_a.txt", output,
+                   "error message names the staged file src/new_a.txt")
 
     branch = repo.get_current_branch()
     repo.assert_equal(default_branch, branch,
@@ -166,40 +167,43 @@ def run_tests(repo: TestRepo):
                       "no git stashes were created")
 
     staged = repo.get_staged_files()
-    repo.assert_in("dddd", staged, "dddd still staged (state untouched)")
+    repo.assert_in("new_b.txt", staged,
+                   "new_b.txt still staged (state untouched)")
 
     # =================================================================
     # Test: after unstaging, the workflow succeeds without leaks
     # =================================================================
-    # This is the leak scenario from issue #51: previously dddd
+    # This is the leak scenario from issue #51: previously new_b.txt
     # reappeared (staged) on the new branch although it belongs to the
-    # stashed changelist xxx.
+    # stashed changelist 'feature-b'.
 
     repo.section("After unstaging the workflow succeeds without leaks")
 
-    repo.run("git cl unstage ok")
-    repo.run("git cl unstage xxx")
+    repo.run("git cl unstage feature-a")
+    repo.run("git cl unstage feature-b")
 
-    output = repo.run("git cl branch ok")
+    output = repo.run("git cl branch feature-a")
     repo.assert_exit_code(0, "git cl branch should succeed after unstaging")
 
     branch = repo.get_current_branch()
-    repo.assert_equal("ok", branch, "now on branch 'ok'")
+    repo.assert_equal("feature-a", branch, "now on branch 'feature-a'")
 
     cl = repo.load_cl_json()
-    repo.assert_true("ok" in cl, "changelist ok active on new branch")
-    repo.assert_true(repo.file_exists("folder1/file1.txt"),
-                     "folder1/file1.txt restored on new branch")
+    repo.assert_true("feature-a" in cl,
+                     "changelist 'feature-a' active on new branch")
+    repo.assert_true(repo.file_exists("src/new_a.txt"),
+                     "src/new_a.txt restored on new branch")
 
-    # The crucial check: files of the stashed changelist xxx must NOT
-    # leak onto the new branch
-    repo.assert_true(not repo.file_exists("dddd"),
-                     "dddd did NOT leak onto the new branch")
+    # The crucial check: files of the stashed changelist 'feature-b'
+    # must NOT leak onto the new branch
+    repo.assert_true(not repo.file_exists("new_b.txt"),
+                     "new_b.txt did NOT leak onto the new branch")
     repo.assert_equal("a", repo.read_file("mod_a.txt"),
-                      "mod_a.txt reverted (changelist xxx stashed)")
+                      "mod_a.txt reverted (changelist 'feature-b' stashed)")
 
     stash = repo.load_stash_json()
-    repo.assert_true("xxx" in stash, "changelist xxx is stashed")
+    repo.assert_true("feature-b" in stash,
+                     "changelist 'feature-b' is stashed")
 
     # =================================================================
     # Test: a single changelist with staged files still works
@@ -212,27 +216,27 @@ def run_tests(repo: TestRepo):
     # Clean up the previous scenario: restore the stashed changelist,
     # revert everything (staged-new files become untracked and are
     # removed by git clean) and delete the changelists
-    repo.run("git cl unstash xxx --force")
+    repo.run("git cl unstash feature-b --force")
     repo.run("git checkout --quiet " + default_branch)
     repo.run("git reset --quiet --hard HEAD")
     repo.run("git clean --quiet -fd")
     repo.run("git cl delete --all")
 
-    repo.write_file("solo.txt", "solo")
-    repo.run("git add solo.txt")
-    repo.run("git cl add solo solo.txt")
+    repo.write_file("standalone.txt", "standalone")
+    repo.run("git add standalone.txt")
+    repo.run("git cl add standalone standalone.txt")
 
-    output = repo.run("git cl branch solo")
+    output = repo.run("git cl branch standalone")
     repo.assert_exit_code(0,
                           "git cl branch with single staged changelist "
                           "should succeed")
 
     branch = repo.get_current_branch()
-    repo.assert_equal("solo", branch, "now on branch 'solo'")
+    repo.assert_equal("standalone", branch, "now on branch 'standalone'")
 
     staged = repo.get_staged_files()
-    repo.assert_in("solo.txt", staged,
-                   "solo.txt restored as staged on the new branch")
+    repo.assert_in("standalone.txt", staged,
+                   "standalone.txt restored as staged on the new branch")
 
 
 # =================================================================


### PR DESCRIPTION
## Summary

Fixes #51. Previously, `git cl br` could leave the repository in an inconsistent state: when one changelist contained unstashable files (e.g. clean files), `cl_stash` aborted with an error but returned `None`, so the workflow could not recognise the failure. The branch was created on top of a dirty working directory, the final unstash failed silently, and the command still reported success, leaving an orphaned git stash behind.

## Changes

- Add a pre-flight check in `cl_branch`  (`clutil_validate_changelists_stashable`) that verifies every active changelist is fully stashable and aborts with clean-up hints before  mutating any state (fail-fast)
- Reject staged files when more than one changelist is stashed: git  records the full index in every pathspec-limited stash, so staged  files leak into other changelists' stashes and reappear when those stashes are applied; the error message recommends removing them from  the index first (`git cl unstage`)
- `cl_stash`/`cl_unstash` now return a success flag; the `--all`  helpers return `(success_count, total)` and count only genuine  successes
- `cl_branch` aborts and restores stashes if stashing is incomplete,  and reports an honest error instead of a false success message when  the final unstash fails

## Tests

- New `tests/test_branch_preflight.py` covering: clean files blocking the workflow, recovery after clean-up, staged files in multiple  changelists, the leak scenario after unstaging, and the unaffected  single-changelist case (32 assertions)
- Full existing suite passes (16/16 scripts, no regressions)
